### PR TITLE
Testing a style-check, with style fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /composer.lock
 /clover.xml
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,22 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor')
+    ->files()
+    ->in(__DIR__)
+;
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR2' => true,
+        '@PHPUnit60Migration:risky' => true,
+        'binary_operator_spaces' => ['align_double_arrow' => true, 'align_equals' => true],
+        'single_quote' => true,
+        'array_syntax' => ['syntax' => 'long'],
+        'concat_space' => ['spacing' => 'one'],
+        'psr0' => true
+    ])
+    ->setUsingCache(true)
+    ->setFinder($finder);
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
 
 stages:
   - test
+  - style check
   - phpstan analysis
   - test with coverage
 
@@ -37,6 +38,11 @@ jobs:
   allow_failures:
     - php: nightly
   include:
+    - stage: style check
+      php: 7.1
+      env: TMPDIR=/tmp USE_XDEBUG=false
+      script:
+        - composer style-check
     - stage: phpstan analysis
       php: 7.1
       env: TMPDIR=/tmp USE_XDEBUG=false

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "phpstan/phpstan": "^0.9.2",
         "jetbrains/phpstorm-stubs": "dev-phpstan",
         "friendsofphp/php-cs-fixer": "^2.11",
-        "squizlabs/php_codesniffer": "^3.2"
+        "maglnet/composer-require-checker": "^0.1.6 | ^0.2.1",
+        "phpro/grumphp": "^0.14.0"
     },
     "archive": {
         "exclude": ["/tests"]
@@ -51,9 +52,9 @@
     ],
     "scripts": {
         "test": "phpunit ./tests",
-        "test-with-coverage": "phpunit --coverage-clover=clover.xml ./tests",
-        "phpstan": "phpstan analyze -l7 -c phpstan.neon --no-progress ./src --ansi",
-        "style-check": "phpcs --standard=Zend -n ./src/ ./tests/ && php-cs-fixer fix --dry-run -vv"
+        "test-with-coverage": "phpunit --coverage-clover=clover.xml",
+        "phpstan": "phpstan analyze -l7 -c phpstan.neon --no-progress ./ --ansi",
+        "style-check": "php-cs-fixer fix --dry-run -vv"
     },
     "suggest": {
         "diablomedia/zendframework1-log-writer-db": "Writer that uses Zend_Db",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,9 @@
     "require-dev": {
         "phpunit/phpunit": "^6.0",
         "phpstan/phpstan": "^0.9.2",
-        "jetbrains/phpstorm-stubs": "dev-phpstan"
+        "jetbrains/phpstorm-stubs": "dev-phpstan",
+        "friendsofphp/php-cs-fixer": "^2.11",
+        "squizlabs/php_codesniffer": "^3.2"
     },
     "archive": {
         "exclude": ["/tests"]
@@ -50,7 +52,8 @@
     "scripts": {
         "test": "phpunit ./tests",
         "test-with-coverage": "phpunit --coverage-clover=clover.xml ./tests",
-        "phpstan": "phpstan analyze -l7 -c phpstan.neon --no-progress ./src --ansi"
+        "phpstan": "phpstan analyze -l7 -c phpstan.neon --no-progress ./src --ansi",
+        "style-check": "phpcs --standard=Zend -n ./src/ ./tests/ && php-cs-fixer fix --dry-run -vv"
     },
     "suggest": {
         "diablomedia/zendframework1-log-writer-db": "Writer that uses Zend_Db",

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -1,0 +1,17 @@
+# grumphp.yml
+parameters:
+    tasks:
+        composer:
+            strict: true
+        composer_require_checker:
+            config_file: require-checker-config.json
+        phpcsfixer2:
+            allow_risky: true
+            config: .php_cs
+        phpstan:
+            level: 7
+            configuration: phpstan.neon
+        phpunit:
+            metadata:
+                priority: 100
+            always_execute: true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,7 @@
 parameters:
+    excludes_analyse:
+        - %rootDir%/../../../tests/*
+        - %rootDir%/../../../vendor/*
     bootstrap: %rootDir%/../../../phpstan-bootstrap.php
     ignoreErrors:
         - '#Casting to string something that.s already string\.#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,11 @@
     backupGlobals="true"
     stderr="true"
     colors="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>

--- a/require-checker-config.json
+++ b/require-checker-config.json
@@ -1,0 +1,9 @@
+{
+  "symbol-whitelist" : [
+    "null", "true", "false",
+    "static", "self", "parent",
+    "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object",
+    "DOMDocument", "DOMElement",
+    "zend_monitor_custom_event", "monitor_custom_event"
+  ]
+}

--- a/src/Zend/Log.php
+++ b/src/Zend/Log.php
@@ -39,14 +39,14 @@
  */
 class Zend_Log
 {
-    const EMERG   = 0;  // Emergency: system is unusable
-    const ALERT   = 1;  // Alert: action must be taken immediately
-    const CRIT    = 2;  // Critical: critical conditions
-    const ERR     = 3;  // Error: error conditions
-    const WARN    = 4;  // Warning: warning conditions
-    const NOTICE  = 5;  // Notice: normal but significant condition
-    const INFO    = 6;  // Informational: informational messages
-    const DEBUG   = 7;  // Debug: debug messages
+    const EMERG  = 0;  // Emergency: system is unusable
+    const ALERT  = 1;  // Alert: action must be taken immediately
+    const CRIT   = 2;  // Critical: critical conditions
+    const ERR    = 3;  // Error: error conditions
+    const WARN   = 4;  // Warning: warning conditions
+    const NOTICE = 5;  // Notice: normal but significant condition
+    const INFO   = 6;  // Informational: informational messages
+    const DEBUG  = 7;  // Debug: debug messages
 
     /**
      * @var array of priorities where the keys are the
@@ -91,7 +91,7 @@ class Zend_Log
      *
      * @var callable
      */
-    protected $_origErrorHandler       = null;
+    protected $_origErrorHandler = null;
 
     /**
      *
@@ -103,13 +103,13 @@ class Zend_Log
      *
      * @var array|boolean
      */
-    protected $_errorHandlerMap        = false;
+    protected $_errorHandlerMap = false;
 
     /**
      *
      * @var string
      */
-    protected $_timestampFormat        = 'c';
+    protected $_timestampFormat = 'c';
 
     /**
      * Class constructor.  Create a new logger
@@ -118,7 +118,7 @@ class Zend_Log
      */
     public function __construct(Zend_Log_Writer_Abstract $writer = null)
     {
-        $r = new ReflectionClass($this);
+        $r                 = new ReflectionClass($this);
         $this->_priorities = array_flip($r->getConstants());
 
         if ($writer !== null) {
@@ -134,7 +134,7 @@ class Zend_Log
      * @return Zend_Log
      * @throws Zend_Log_Exception
      */
-    static public function factory($config = array())
+    public static function factory($config = array())
     {
         if ($config instanceof Zend_Config) {
             $config = $config->toArray();
@@ -167,7 +167,7 @@ class Zend_Log
         if (!is_array(current($config))) {
             $log->addWriter(current($config));
         } else {
-            foreach($config as $writer) {
+            foreach ($config as $writer) {
                 $log->addWriter($writer);
             }
         }
@@ -219,7 +219,7 @@ class Zend_Log
         $filter = $this->_constructFromConfig('filter', $config, $this->_defaultFilterNamespace);
 
         if (!$filter instanceof Zend_Log_Filter_Interface) {
-             $filterName = is_object($filter)
+            $filterName = is_object($filter)
                          ? get_class($filter)
                          : 'The specified filter';
             throw new Zend_Log_Exception("{$filterName} does not implement Zend_Log_Filter_Interface");
@@ -228,19 +228,19 @@ class Zend_Log
         return $filter;
     }
 
-   /**
-    * Construct formatter object from configuration array or Zend_Config object
-    *
-    * @param  array|Zend_Config $config Zend_Config or Array
-    * @return Zend_Log_Formatter_Interface
-    * @throws Zend_Log_Exception
-    */
+    /**
+     * Construct formatter object from configuration array or Zend_Config object
+     *
+     * @param  array|Zend_Config $config Zend_Config or Array
+     * @return Zend_Log_Formatter_Interface
+     * @throws Zend_Log_Exception
+     */
     protected function _constructFormatterFromConfig($config)
     {
         $formatter = $this->_constructFromConfig('formatter', $config, $this->_defaultFormatterNamespace);
 
         if (!$formatter instanceof Zend_Log_Formatter_Interface) {
-             $formatterName = is_object($formatter)
+            $formatterName = is_object($formatter)
                          ? get_class($formatter)
                          : 'The specified formatter';
             throw new Zend_Log_Exception($formatterName . ' does not implement Zend_Log_Formatter_Interface');
@@ -270,7 +270,7 @@ class Zend_Log
             );
         }
 
-        $params    = isset($config[ $type .'Params' ]) ? $config[ $type .'Params' ] : array();
+        $params    = isset($config[ $type . 'Params' ]) ? $config[ $type . 'Params' ] : array();
         $className = $this->getClassName($config, $type, $namespace);
         if (!class_exists($className)) {
             Zend_Loader::loadClass($className);
@@ -330,7 +330,8 @@ class Zend_Log
      */
     protected function _packEvent($message, $priority)
     {
-        return array_merge(array(
+        return array_merge(
+            array(
             'timestamp'    => date($this->_timestampFormat),
             'message'      => $message,
             'priority'     => $priority,
@@ -348,7 +349,7 @@ class Zend_Log
     public function __destruct()
     {
         /** @var Zend_Log_Writer_Abstract $writer */
-        foreach($this->_writers as $writer) {
+        foreach ($this->_writers as $writer) {
             $writer->shutdown();
         }
     }
@@ -373,7 +374,7 @@ class Zend_Log
                     throw new Zend_Log_Exception('Missing log message');
                 case 1:
                     $message = array_shift($params);
-                    $extras = null;
+                    $extras  = null;
                     break;
                 default:
                     $message = array_shift($params);
@@ -479,11 +480,9 @@ class Zend_Log
         if (is_int($filter)) {
             /** @see Zend_Log_Filter_Priority */
             $filter = new Zend_Log_Filter_Priority($filter);
-
         } elseif ($filter instanceof Zend_Config || is_array($filter)) {
             $filter = $this->_constructFilterFromConfig($filter);
-
-        } elseif(! $filter instanceof Zend_Log_Filter_Interface) {
+        } elseif (! $filter instanceof Zend_Log_Filter_Interface) {
             throw new Zend_Log_Exception('Invalid filter provided');
         }
 
@@ -600,7 +599,11 @@ class Zend_Log
             } else {
                 $priority = Zend_Log::INFO;
             }
-            $this->log($errstr, $priority, array('errno'=>$errno, 'file'=>$errfile, 'line'=>$errline, 'context'=>$errcontext));
+            $this->log(
+                $errstr,
+                $priority,
+                array('errno'=> $errno, 'file'=>$errfile, 'line'=>$errline, 'context'=>$errcontext)
+            );
         }
 
         if ($this->_origErrorHandler !== null) {

--- a/src/Zend/Log/Exception.php
+++ b/src/Zend/Log/Exception.php
@@ -27,4 +27,5 @@
  * @version    $Id$
  */
 class Zend_Log_Exception extends Zend_Exception
-{}
+{
+}

--- a/src/Zend/Log/FactoryInterface.php
+++ b/src/Zend/Log/FactoryInterface.php
@@ -34,5 +34,5 @@ interface Zend_Log_FactoryInterface
      * @param  array|Zend_Config $config
      * @return Zend_Log_FactoryInterface
      */
-    static public function factory($config);
+    public static function factory($config);
 }

--- a/src/Zend/Log/Filter/Abstract.php
+++ b/src/Zend/Log/Filter/Abstract.php
@@ -28,8 +28,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @version    $Id$
  */
-abstract class Zend_Log_Filter_Abstract
-    implements Zend_Log_Filter_Interface, Zend_Log_FactoryInterface
+abstract class Zend_Log_Filter_Abstract implements Zend_Log_Filter_Interface, Zend_Log_FactoryInterface
 {
     /**
      * Validate and optionally convert the config to array
@@ -38,7 +37,7 @@ abstract class Zend_Log_Filter_Abstract
      * @return array
      * @throws Zend_Log_Exception
      */
-    static protected function _parseConfig($config)
+    protected static function _parseConfig($config)
     {
         if ($config instanceof Zend_Config) {
             $config = $config->toArray();

--- a/src/Zend/Log/Filter/Message.php
+++ b/src/Zend/Log/Filter/Message.php
@@ -56,12 +56,15 @@ class Zend_Log_Filter_Message extends Zend_Log_Filter_Abstract
      * @param  array|Zend_Config $config
      * @return Zend_Log_Filter_Message
      */
-    static public function factory($config)
+    public static function factory($config)
     {
         $config = self::_parseConfig($config);
-        $config = array_merge(array(
+        $config = array_merge(
+            array(
             'regexp' => null
-        ), $config);
+            ),
+            $config
+        );
 
         return new self(
             $config['regexp']

--- a/src/Zend/Log/Filter/Priority.php
+++ b/src/Zend/Log/Filter/Priority.php
@@ -65,13 +65,16 @@ class Zend_Log_Filter_Priority extends Zend_Log_Filter_Abstract
      * @param  array|Zend_Config $config
      * @return Zend_Log_Filter_Priority
      */
-    static public function factory($config)
+    public static function factory($config)
     {
         $config = self::_parseConfig($config);
-        $config = array_merge(array(
+        $config = array_merge(
+            array(
             'priority' => null,
             'operator' => null,
-        ), $config);
+            ),
+            $config
+        );
 
         // Add support for constants
         if (!is_numeric($config['priority']) && isset($config['priority']) && defined($config['priority'])) {

--- a/src/Zend/Log/Filter/Suppress.php
+++ b/src/Zend/Log/Filter/Suppress.php
@@ -67,7 +67,7 @@ class Zend_Log_Filter_Suppress extends Zend_Log_Filter_Abstract
      * @return Zend_Log_Filter_Suppress
      * @throws Zend_Log_Exception
      */
-    static public function factory($config)
+    public static function factory($config)
     {
         return new self();
     }

--- a/src/Zend/Log/Formatter/Abstract.php
+++ b/src/Zend/Log/Formatter/Abstract.php
@@ -28,7 +28,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @version    $Id$
  */
-abstract class Zend_Log_Formatter_Abstract
-    implements Zend_Log_Formatter_Interface, Zend_Log_FactoryInterface
+abstract class Zend_Log_Formatter_Abstract implements Zend_Log_Formatter_Interface, Zend_Log_FactoryInterface
 {
 }

--- a/src/Zend/Log/Formatter/Firebug.php
+++ b/src/Zend/Log/Formatter/Firebug.php
@@ -30,10 +30,10 @@
 class Zend_Log_Formatter_Firebug extends Zend_Log_Formatter_Abstract
 {
     /**
-	 * Factory for Zend_Log_Formatter_Firebug classe
-	 *
+     * Factory for Zend_Log_Formatter_Firebug classe
+     *
      * @param array|Zend_Config $options useless
-	 * @return Zend_Log_Formatter_Firebug
+     * @return Zend_Log_Formatter_Firebug
      */
     public static function factory($options)
     {

--- a/src/Zend/Log/Formatter/Interface.php
+++ b/src/Zend/Log/Formatter/Interface.php
@@ -37,5 +37,4 @@ interface Zend_Log_Formatter_Interface
      * @return string             formatted line to write to the log
      */
     public function format($event);
-
 }

--- a/src/Zend/Log/Formatter/Simple.php
+++ b/src/Zend/Log/Formatter/Simple.php
@@ -58,10 +58,10 @@ class Zend_Log_Formatter_Simple extends Zend_Log_Formatter_Abstract
     }
 
     /**
-	 * Factory for Zend_Log_Formatter_Simple classe
-	 *
-	 * @param array|Zend_Config $options
-	 * @return Zend_Log_Formatter_Simple
+     * Factory for Zend_Log_Formatter_Simple classe
+     *
+     * @param array|Zend_Config $options
+     * @return Zend_Log_Formatter_Simple
      */
     public static function factory($options)
     {
@@ -90,7 +90,7 @@ class Zend_Log_Formatter_Simple extends Zend_Log_Formatter_Abstract
         $output = $this->_format;
 
         foreach ($event as $name => $value) {
-            if ((is_object($value) && !method_exists($value,'__toString'))
+            if ((is_object($value) && !method_exists($value, '__toString'))
                 || is_array($value)
             ) {
                 $value = gettype($value);

--- a/src/Zend/Log/Formatter/Xml.php
+++ b/src/Zend/Log/Formatter/Xml.php
@@ -60,7 +60,7 @@ class Zend_Log_Formatter_Xml extends Zend_Log_Formatter_Abstract
             $args = func_get_args();
 
             $options = array(
-            	'rootElement' => array_shift($args)
+                'rootElement' => array_shift($args)
             );
 
             if (count($args)) {
@@ -84,15 +84,15 @@ class Zend_Log_Formatter_Xml extends Zend_Log_Formatter_Abstract
         $this->setEncoding($options['encoding']);
 
         if (array_key_exists('elementMap', $options)) {
-            $this->_elementMap  = $options['elementMap'];
+            $this->_elementMap = $options['elementMap'];
         }
     }
 
     /**
-	 * Factory for Zend_Log_Formatter_Xml classe
-	 *
-	 * @param array|Zend_Config $options
-	 * @return Zend_Log_Formatter_Xml
+     * Factory for Zend_Log_Formatter_Xml classe
+     *
+     * @param array|Zend_Config $options
+     * @return Zend_Log_Formatter_Xml
      */
     public static function factory($options)
     {
@@ -143,11 +143,11 @@ class Zend_Log_Formatter_Xml extends Zend_Log_Formatter_Abstract
         $elt = $dom->appendChild(new DOMElement($this->_rootElement));
 
         foreach ($dataToInsert as $key => $value) {
-            if (empty($value) 
-                || is_scalar($value) 
-                || (is_object($value) && method_exists($value,'__toString'))
+            if (empty($value)
+                || is_scalar($value)
+                || (is_object($value) && method_exists($value, '__toString'))
             ) {
-                if($key == "message") {
+                if ($key == 'message') {
                     $value = htmlspecialchars($value, ENT_COMPAT, $enc);
                 }
                 $elt->appendChild(new DOMElement($key, (string)$value));

--- a/src/Zend/Log/Writer/Abstract.php
+++ b/src/Zend/Log/Writer/Abstract.php
@@ -101,7 +101,8 @@ abstract class Zend_Log_Writer_Abstract implements Zend_Log_FactoryInterface
      * @return void
      */
     public function shutdown()
-    {}
+    {
+    }
 
     /**
      * Write a message to the log.
@@ -118,7 +119,7 @@ abstract class Zend_Log_Writer_Abstract implements Zend_Log_FactoryInterface
      * @return array
      * @throws Zend_Log_Exception
      */
-    static protected function _parseConfig($config)
+    protected static function _parseConfig($config)
     {
         if ($config instanceof Zend_Config) {
             $config = $config->toArray();

--- a/src/Zend/Log/Writer/Mock.php
+++ b/src/Zend/Log/Writer/Mock.php
@@ -71,7 +71,7 @@ class Zend_Log_Writer_Mock extends Zend_Log_Writer_Abstract
      * @param  array|Zend_Config $config
      * @return Zend_Log_Writer_Mock
      */
-    static public function factory($config)
+    public static function factory($config)
     {
         return new self();
     }

--- a/src/Zend/Log/Writer/Null.php
+++ b/src/Zend/Log/Writer/Null.php
@@ -46,7 +46,7 @@ class Zend_Log_Writer_Null extends Zend_Log_Writer_Abstract
      * @param  array|Zend_Config $config
      * @return Zend_Log_Writer_Null
      */
-    static public function factory($config)
+    public static function factory($config)
     {
         return new self();
     }

--- a/src/Zend/Log/Writer/Stream.php
+++ b/src/Zend/Log/Writer/Stream.php
@@ -82,13 +82,16 @@ class Zend_Log_Writer_Stream extends Zend_Log_Writer_Abstract
      * @param  array|Zend_Config $config
      * @return Zend_Log_Writer_Stream
      */
-    static public function factory($config)
+    public static function factory($config)
     {
         $config = self::_parseConfig($config);
-        $config = array_merge(array(
+        $config = array_merge(
+            array(
             'stream' => null,
             'mode'   => null,
-        ), $config);
+            ),
+            $config
+        );
 
         $streamOrUrl = isset($config['url']) ? $config['url'] : $config['stream'];
 
@@ -122,7 +125,7 @@ class Zend_Log_Writer_Stream extends Zend_Log_Writer_Abstract
         $line = $this->_formatter->format($event);
 
         if (false === @fwrite($this->_stream, $line)) {
-            throw new Zend_Log_Exception("Unable to write to stream");
+            throw new Zend_Log_Exception('Unable to write to stream');
         }
     }
 }

--- a/src/Zend/Log/Writer/Syslog.php
+++ b/src/Zend/Log/Writer/Syslog.php
@@ -118,7 +118,7 @@ class Zend_Log_Writer_Syslog extends Zend_Log_Writer_Abstract
      * @param  array|Zend_Config $config
      * @return Zend_Log_Writer_Syslog
      */
-    static public function factory($config)
+    public static function factory($config)
     {
         return new self(self::_parseConfig($config));
     }
@@ -189,7 +189,9 @@ class Zend_Log_Writer_Syslog extends Zend_Log_Writer_Abstract
         }
 
         if (!in_array($facility, $this->_validFacilities)) {
-            throw new Zend_Log_Exception('Invalid log facility provided; please see http://php.net/openlog for a list of valid facility values');
+            throw new Zend_Log_Exception(
+                'Invalid log facility provided; please see http://php.net/openlog for a list of valid facility values'
+            );
         }
 
         if ('WIN' == strtoupper(substr(PHP_OS, 0, 3))
@@ -244,8 +246,7 @@ class Zend_Log_Writer_Syslog extends Zend_Log_Writer_Abstract
         }
 
         if ($this->_application !== self::$_lastApplication
-            || $this->_facility !== self::$_lastFacility)
-        {
+            || $this->_facility !== self::$_lastFacility) {
             $this->_initializeSyslog();
         }
 

--- a/src/Zend/Log/Writer/ZendMonitor.php
+++ b/src/Zend/Log/Writer/ZendMonitor.php
@@ -63,7 +63,7 @@ class Zend_Log_Writer_ZendMonitor extends Zend_Log_Writer_Abstract
      * @param  array|Zend_Config $config
      * @return Zend_Log_Writer_ZendMonitor
      */
-    static public function factory($config)
+    public static function factory($config)
     {
         return new self();
     }

--- a/tests/Zend/Log/Filter/ChainingTest.php
+++ b/tests/Zend/Log/Filter/ChainingTest.php
@@ -33,7 +33,7 @@ class Zend_Log_Filter_ChainingTest extends PHPUnit\Framework\TestCase
 {
     public function setUp()
     {
-        $this->log = fopen('php://memory', 'w');
+        $this->log    = fopen('php://memory', 'w');
         $this->logger = new Zend_Log();
         $this->logger->addWriter(new Zend_Log_Writer_Stream($this->log));
     }
@@ -49,7 +49,7 @@ class Zend_Log_Filter_ChainingTest extends PHPUnit\Framework\TestCase
         $this->logger->addFilter(Zend_Log::WARN);
 
         $this->logger->info($ignored = 'info-message-ignored');
-        $this->logger->warn($logged  = 'warn-message-logged');
+        $this->logger->warn($logged = 'warn-message-logged');
 
         rewind($this->log);
         $logdata = stream_get_contents($this->log);
@@ -60,7 +60,7 @@ class Zend_Log_Filter_ChainingTest extends PHPUnit\Framework\TestCase
 
     public function testFilterOnSpecificWriter()
     {
-        $log2 = fopen('php://memory', 'w');
+        $log2    = fopen('php://memory', 'w');
         $writer2 = new Zend_Log_Writer_Stream($log2);
         $writer2->addFilter(Zend_Log::ERR);
 

--- a/tests/Zend/Log/Filter/MessageTest.php
+++ b/tests/Zend/Log/Filter/MessageTest.php
@@ -52,10 +52,10 @@ class Zend_Log_Filter_MessageTest extends PHPUnit\Framework\TestCase
     public function testFactory()
     {
         $cfg = array('log' => array('memory' => array(
-            'writerName'   => "Mock",
-            'filterName'   => "Message",
+            'writerName'   => 'Mock',
+            'filterName'   => 'Message',
             'filterParams' => array(
-                'regexp'   => "/42/"
+                'regexp'   => '/42/'
              ),
         )));
 
@@ -65,13 +65,15 @@ class Zend_Log_Filter_MessageTest extends PHPUnit\Framework\TestCase
 
     public function testFactoryWithConfig()
     {
-        $config = new Zend_Config(array('log' => array('memory' => array(
-            'writerName'   => "Mock",
-            'filterName'   => "Message",
+        $config = new Zend_Config(
+            array('log' => array('memory' => array(
+            'writerName'   => 'Mock',
+            'filterName'   => 'Message',
             'filterParams' => array(
-                'regexp'   => "/42/"
+                'regexp'   => '/42/'
              ),
-        ))));
+            )))
+        );
 
         $filter = Zend_Log_Filter_Message::factory($config->log->memory->filterParams);
         $this->assertTrue($filter instanceof Zend_Log_Filter_Message);

--- a/tests/Zend/Log/Filter/PriorityTest.php
+++ b/tests/Zend/Log/Filter/PriorityTest.php
@@ -65,11 +65,11 @@ class Zend_Log_Filter_PriorityTest extends PHPUnit\Framework\TestCase
     public function testFactory()
     {
         $cfg = array('log' => array('memory' => array(
-            'writerName' => "Mock",
-            'filterName' => "Priority",
+            'writerName'   => 'Mock',
+            'filterName'   => 'Priority',
             'filterParams' => array(
-                'priority' => "Zend_Log::CRIT",
-                'operator' => "<="
+                'priority' => 'Zend_Log::CRIT',
+                'operator' => '<='
              ),
         )));
 
@@ -77,12 +77,14 @@ class Zend_Log_Filter_PriorityTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($logger instanceof Zend_Log);
 
         try {
-            $logger = Zend_Log::factory(array('Null' => array(
+            $logger = Zend_Log::factory(
+                array('Null' => array(
                 'writerName'   => 'Mock',
                 'filterName'   => 'Priority',
                 'filterParams' => array(),
-            )));
-        } catch(Exception $e) {
+                ))
+            );
+        } catch (Exception $e) {
             $this->assertTrue($e instanceof Zend_Log_Exception);
             $this->assertRegExp('/must be an integer/', $e->getMessage());
         }

--- a/tests/Zend/Log/Filter/SuppressTest.php
+++ b/tests/Zend/Log/Filter/SuppressTest.php
@@ -68,8 +68,8 @@ class Zend_Log_Filter_SuppressTest extends PHPUnit\Framework\TestCase
     public function testFactory()
     {
         $cfg = array('log' => array('memory' => array(
-            'writerName' => "Mock",
-            'filterName' => "Suppress"
+            'writerName' => 'Mock',
+            'filterName' => 'Suppress'
         )));
 
         $logger = Zend_Log::factory($cfg['log']);

--- a/tests/Zend/Log/Formatter/FirebugTest.php
+++ b/tests/Zend/Log/Formatter/FirebugTest.php
@@ -34,13 +34,13 @@ class Zend_Log_Formatter_FirebugTest extends PHPUnit\Framework\TestCase
     public function testFormat()
     {
         $event = array(
-            'timestamp' => date('c'),
-        	'message' => 'tottakai',
-            'priority' => 2,
-        	'priorityName' => 'CRIT'
+            'timestamp'    => date('c'),
+            'message'      => 'tottakai',
+            'priority'     => 2,
+            'priorityName' => 'CRIT'
         );
         $formatter = new Zend_Log_Formatter_Firebug();
-        $output = $formatter->format($event);
+        $output    = $formatter->format($event);
 
         $this->assertEquals('tottakai', $output);
     }
@@ -50,7 +50,7 @@ class Zend_Log_Formatter_FirebugTest extends PHPUnit\Framework\TestCase
      */
     public function testFactory()
     {
-        $options = array();
+        $options   = array();
         $formatter = Zend_Log_Formatter_Firebug::factory($options);
         $this->assertTrue($formatter instanceof Zend_Log_Formatter_Firebug);
     }

--- a/tests/Zend/Log/Formatter/SimpleTest.php
+++ b/tests/Zend/Log/Formatter/SimpleTest.php
@@ -49,7 +49,7 @@ class Zend_Log_Formatter_SimpleTest extends PHPUnit\Framework\TestCase
                         'priority'     => 42,
                         'priorityName' => 'bar');
 
-        $f = new Zend_Log_Formatter_Simple();
+        $f    = new Zend_Log_Formatter_Simple();
         $line = $f->format($fields);
 
         $this->assertContains((string)$fields['timestamp'], $line);
@@ -67,36 +67,36 @@ class Zend_Log_Formatter_SimpleTest extends PHPUnit\Framework\TestCase
         $f = new Zend_Log_Formatter_Simple();
 
         $fields['message'] = 'Foo';
-        $line = $f->format($fields);
+        $line              = $f->format($fields);
         $this->assertContains($fields['message'], $line);
 
         $fields['message'] = 10;
-        $line = $f->format($fields);
+        $line              = $f->format($fields);
         $this->assertContains((string) $fields['message'], $line);
 
         $fields['message'] = 10.5;
-        $line = $f->format($fields);
+        $line              = $f->format($fields);
         $this->assertContains((string) $fields['message'], $line);
 
         $fields['message'] = true;
-        $line = $f->format($fields);
+        $line              = $f->format($fields);
         $this->assertContains('1', $line);
 
         $fields['message'] = fopen('php://stdout', 'w');
-        $line = $f->format($fields);
+        $line              = $f->format($fields);
         $this->assertContains('Resource id ', $line);
         fclose($fields['message']);
 
-        $fields['message'] = range(1,10);
-        $line = $f->format($fields);
+        $fields['message'] = range(1, 10);
+        $line              = $f->format($fields);
         $this->assertContains('array', $line);
 
         $fields['message'] = new Zend_Log_Formatter_SimpleTest_TestObject1();
-        $line = $f->format($fields);
+        $line              = $f->format($fields);
         $this->assertContains($fields['message']->__toString(), $line);
 
         $fields['message'] = new Zend_Log_Formatter_SimpleTest_TestObject2();
-        $line = $f->format($fields);
+        $line              = $f->format($fields);
         $this->assertContains('object', $line);
     }
 
@@ -113,13 +113,14 @@ class Zend_Log_Formatter_SimpleTest extends PHPUnit\Framework\TestCase
     }
 }
 
-class Zend_Log_Formatter_SimpleTest_TestObject1 {
-
+class Zend_Log_Formatter_SimpleTest_TestObject1
+{
     public function __toString()
     {
         return 'Hello World';
     }
 }
 
-class Zend_Log_Formatter_SimpleTest_TestObject2 {
+class Zend_Log_Formatter_SimpleTest_TestObject2
+{
 }

--- a/tests/Zend/Log/Formatter/XmlTest.php
+++ b/tests/Zend/Log/Formatter/XmlTest.php
@@ -33,7 +33,7 @@ class Zend_Log_Formatter_XmlTest extends PHPUnit\Framework\TestCase
 {
     public function testDefaultFormat()
     {
-        $f = new Zend_Log_Formatter_Xml();
+        $f    = new Zend_Log_Formatter_Xml();
         $line = $f->format(array('message' => 'foo', 'priority' => 42));
 
         $this->assertContains('foo', $line);
@@ -42,14 +42,14 @@ class Zend_Log_Formatter_XmlTest extends PHPUnit\Framework\TestCase
 
     public function testConfiguringElementMapping()
     {
-        $f = new Zend_Log_Formatter_Xml('log', array('foo' => 'bar'));
+        $f    = new Zend_Log_Formatter_Xml('log', array('foo' => 'bar'));
         $line = $f->format(array('bar' => 'baz'));
         $this->assertContains('<log><foo>baz</foo></log>', $line);
     }
 
     public function testXmlDeclarationIsStripped()
     {
-        $f = new Zend_Log_Formatter_Xml();
+        $f    = new Zend_Log_Formatter_Xml();
         $line = $f->format(array('message' => 'foo', 'priority' => 42));
 
         $this->assertNotContains('<\?xml version=', $line);
@@ -57,7 +57,7 @@ class Zend_Log_Formatter_XmlTest extends PHPUnit\Framework\TestCase
 
     public function testXmlValidates()
     {
-        $f = new Zend_Log_Formatter_Xml();
+        $f    = new Zend_Log_Formatter_Xml();
         $line = $f->format(array('message' => 'foo', 'priority' => 42));
 
         $sxml = @simplexml_load_string($line);
@@ -70,11 +70,11 @@ class Zend_Log_Formatter_XmlTest extends PHPUnit\Framework\TestCase
      */
     public function testHtmlSpecialCharsInMessageGetEscapedForValidXml()
     {
-        $f = new Zend_Log_Formatter_Xml();
+        $f    = new Zend_Log_Formatter_Xml();
         $line = $f->format(array('message' => '&key1=value1&key2=value2', 'priority' => 42));
 
-        $this->assertContains("&amp;", $line);
-        $this->assertTrue(substr_count($line, "&amp;") == 2);
+        $this->assertContains('&amp;', $line);
+        $this->assertTrue(substr_count($line, '&amp;') == 2);
     }
 
     /**
@@ -83,7 +83,7 @@ class Zend_Log_Formatter_XmlTest extends PHPUnit\Framework\TestCase
      */
     public function testFixingBrokenCharsSoXmlIsValid()
     {
-        $f = new Zend_Log_Formatter_Xml();
+        $f    = new Zend_Log_Formatter_Xml();
         $line = $f->format(array('message' => '&amp', 'priority' => 42));
 
         $this->assertContains('&amp;amp', $line);
@@ -93,19 +93,19 @@ class Zend_Log_Formatter_XmlTest extends PHPUnit\Framework\TestCase
     {
         $options = array(
             'rootElement' => 'log',
-            'elementMap' => array(
-                'word' => 'message',
+            'elementMap'  => array(
+                'word'     => 'message',
                 'priority' => 'priority'
             )
         );
         $event = array(
-            'message' => 'tottakai',
+            'message'  => 'tottakai',
             'priority' => 4
         );
         $expected = '<log><word>tottakai</word><priority>4</priority></log>';
 
         $formatter = new Zend_Log_Formatter_Xml($options);
-        $output = $formatter->format($event);
+        $output    = $formatter->format($event);
         $this->assertContains($expected, $output);
         $this->assertEquals('UTF-8', $formatter->getEncoding());
     }
@@ -117,9 +117,9 @@ class Zend_Log_Formatter_XmlTest extends PHPUnit\Framework\TestCase
     {
         $options = array(
             'rootElement' => 'log',
-            'elementMap' => array(
+            'elementMap'  => array(
                 'timestamp' => 'timestamp',
-                'response' => 'message'
+                'response'  => 'message'
             )
         );
         $formatter = Zend_Log_Formatter_Xml::factory($options);
@@ -135,15 +135,15 @@ class Zend_Log_Formatter_XmlTest extends PHPUnit\Framework\TestCase
             'rootElement' => 'log'
         );
         $event = array(
-            'message' => 'tottakai',
-            'priority' => 4,
-            'context' => array('test'=>'one'),
+            'message'   => 'tottakai',
+            'priority'  => 4,
+            'context'   => array('test'=>'one'),
             'reference' => new Zend_Log_Formatter_Xml()
         );
         $expected = '<log><message>tottakai</message><priority>4</priority></log>';
 
         $formatter = new Zend_Log_Formatter_Xml($options);
-        $output = $formatter->format($event);
+        $output    = $formatter->format($event);
         $this->assertContains($expected, $output);
     }
 
@@ -156,15 +156,16 @@ class Zend_Log_Formatter_XmlTest extends PHPUnit\Framework\TestCase
             'rootElement' => 'log'
         );
         $event = array(
-            'message' => 'tottakai',
-            'priority' => 4,
-            'context' => array('test'=>'one'),
+            'message'   => 'tottakai',
+            'priority'  => 4,
+            'context'   => array('test'=>'one'),
             'reference' => new Zend_Log_Formatter_XmlTest_SerializableObject()
         );
-        $expected = '<log><message>tottakai</message><priority>4</priority><reference>Zend_Log_Formatter_XmlTest_SerializableObject</reference></log>';
+        $expected = '<log><message>tottakai</message><priority>4</priority>' .
+            '<reference>Zend_Log_Formatter_XmlTest_SerializableObject</reference></log>';
 
         $formatter = new Zend_Log_Formatter_Xml($options);
-        $output = $formatter->format($event);
+        $output    = $formatter->format($event);
         $this->assertContains($expected, $output);
     }
 }

--- a/tests/Zend/Log/LogTest.php
+++ b/tests/Zend/Log/LogTest.php
@@ -33,7 +33,7 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
 {
     public function setUp()
     {
-        $this->log = fopen('php://memory', 'w+');
+        $this->log    = fopen('php://memory', 'w+');
         $this->writer = new Zend_Log_Writer_Stream($this->log);
     }
 
@@ -152,7 +152,6 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
             $this->assertTrue($e instanceof Zend_Log_Exception);
             $this->assertRegExp('/existing priorities/i', $e->getMessage());
         }
-
     }
 
     public function testAddLogPriority()
@@ -170,7 +169,8 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
 
     // Fields
 
-    public function testLogWritesStandardFields() {
+    public function testLogWritesStandardFields()
+    {
         $logger = new Zend_Log($mock = new Zend_Log_Writer_Mock);
         $logger->info('foo');
 
@@ -181,7 +181,8 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(array(), array_diff_key($event, $standardFields));
     }
 
-    public function testLogWritesAndOverwritesExtraFields() {
+    public function testLogWritesAndOverwritesExtraFields()
+    {
         $logger = new Zend_Log($mock = new Zend_Log_Writer_Mock);
         $logger->setEventItem('foo', 42);
         $logger->setEventItem($field = 'bar', $value = 43);
@@ -237,10 +238,10 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
     public function testLogConstructFromConfigStream()
     {
         $cfg = array('log' => array('memory' => array(
-            'writerName'      => "Stream",
-            'writerNamespace' => "Zend_Log_Writer",
+            'writerName'      => 'Stream',
+            'writerNamespace' => 'Zend_Log_Writer',
             'writerParams'    => array(
-                'stream'      => "php://memory"
+                'stream'      => 'php://memory'
             )
         )));
 
@@ -251,15 +252,15 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
     public function testLogConstructFromConfigStreamAndFilter()
     {
         $cfg = array('log' => array('memory' => array(
-            'writerName'      => "Stream",
-            'writerNamespace' => "Zend_Log_Writer",
+            'writerName'      => 'Stream',
+            'writerNamespace' => 'Zend_Log_Writer',
             'writerParams'    => array(
-                'stream'      => "php://memory"
+                'stream'      => 'php://memory'
             ),
-            'filterName'   => "Priority",
+            'filterName'   => 'Priority',
             'filterParams' => array(
-                'priority' => "Zend_Log::CRIT",
-                'operator' => "<="
+                'priority' => 'Zend_Log::CRIT',
+                'operator' => '<='
              ),
         )));
 
@@ -270,8 +271,8 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
     public function testFactoryUsesNameAndNamespaceWithoutModifications()
     {
         $cfg = array('log' => array('memory' => array(
-            'writerName'      => "ZendMonitor",
-            'writerNamespace' => "Zend_Log_Writer",
+            'writerName'      => 'ZendMonitor',
+            'writerNamespace' => 'Zend_Log_Writer',
         )));
 
         $logger = Zend_Log::factory($cfg['log']);
@@ -298,16 +299,16 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
         $oldHandler = set_error_handler(array($this, 'verifyHandlerData'));
         $logger->registerErrorHandler();
 
-        trigger_error("Testing notice shows up in logs", E_USER_NOTICE);
-        trigger_error("Testing warning shows up in logs", E_USER_WARNING);
-        trigger_error("Testing error shows up in logs", E_USER_ERROR);
+        trigger_error('Testing notice shows up in logs', E_USER_NOTICE);
+        trigger_error('Testing warning shows up in logs', E_USER_WARNING);
+        trigger_error('Testing error shows up in logs', E_USER_ERROR);
 
         $this->expectingLogging = false;
         error_reporting(0);
 
-        trigger_error("Testing notice misses logs", E_USER_NOTICE);
-        trigger_error("Testing warning misses logs", E_USER_WARNING);
-        trigger_error("Testing error misses logs", E_USER_ERROR);
+        trigger_error('Testing notice misses logs', E_USER_NOTICE);
+        trigger_error('Testing warning misses logs', E_USER_WARNING);
+        trigger_error('Testing error misses logs', E_USER_ERROR);
 
         restore_error_handler(); // Pop off the Logger
         restore_error_handler(); // Pop off the verifyHandlerData
@@ -369,7 +370,10 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
             $logger->addWriter($writer);
         } catch (Exception $e) {
             $this->assertTrue($e instanceof Zend_Log_Exception);
-            $this->assertRegExp('#^(Zend_Log_Writer_NotExtendedWriterAbstract|The\sspecified\swriter)#', $e->getMessage());
+            $this->assertRegExp(
+                '#^(Zend_Log_Writer_NotExtendedWriterAbstract|The\sspecified\swriter)#',
+                $e->getMessage()
+            );
         }
     }
 
@@ -384,7 +388,10 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
             $logger->addFilter($filter);
         } catch (Exception $e) {
             $this->assertTrue($e instanceof Zend_Log_Exception);
-            $this->assertRegExp('#^(Zend_Log_Filter_NotImplementsFilterInterface|The\sspecified\sfilter)#', $e->getMessage());
+            $this->assertRegExp(
+                '#^(Zend_Log_Filter_NotImplementsFilterInterface|The\sspecified\sfilter)#',
+                $e->getMessage()
+            );
         }
     }
 
@@ -407,13 +414,13 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
      */
     public function testPriorityDuplicates()
     {
-        $logger   = new Zend_Log();
-        $mock     = new Zend_Log_Writer_Mock();
+        $logger = new Zend_Log();
+        $mock   = new Zend_Log_Writer_Mock();
         $logger->addWriter($mock);
         try {
             $logger->addPriority('emerg', 8);
             $this->fail();
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->assertTrue($e instanceof Zend_Log_Exception);
             $this->assertEquals('Existing priorities cannot be overwritten', $e->getMessage());
         }
@@ -438,14 +445,14 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
     public function testLogConstructFromConfigFormatter()
     {
         $config = array(
-        	'log' => array(
-	        	'test' => array(
-		            'writerName'    => 'Mock',
-		            'formatterName' => 'Simple',
-		            'formatterParams' => array(
-		                'format' => '%timestamp% (%priorityName%): %message%'
-		            )
-	            )
+            'log' => array(
+                'test' => array(
+                    'writerName'      => 'Mock',
+                    'formatterName'   => 'Simple',
+                    'formatterParams' => array(
+                        'format' => '%timestamp% (%priorityName%): %message%'
+                    )
+                )
             )
         );
 
@@ -453,19 +460,19 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
         $logger->log('custom message', Zend_Log::INFO);
     }
 
-	/**
+    /**
      * @group ZF-9176
      * @doesNotPerformAssertions
      */
     public function testLogConstructFromConfigCustomFormatter()
     {
         $config = array(
-        	'log' => array(
-	        	'test' => array(
-		            'writerName'    => 'Mock',
-		            'formatterName' => 'Mock',
-        			'formatterNamespace' => 'Custom_Formatter'
-	            )
+            'log' => array(
+                'test' => array(
+                    'writerName'         => 'Mock',
+                    'formatterName'      => 'Mock',
+                    'formatterNamespace' => 'Custom_Formatter'
+                )
             )
         );
 
@@ -480,7 +487,7 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
     {
         $config = array(
             'timestampFormat' => 'Y-m-d',
-            'mock' => array(
+            'mock'            => array(
                 'writerName' => 'Mock'
             )
         );
@@ -496,7 +503,7 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
     {
         $config = array(
             'timestampFormat' => '',
-            'mock' => array(
+            'mock'            => array(
                 'writerName' => 'Mock'
             )
         );
@@ -527,7 +534,6 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
 
             $logger = Zend_Log::factory($config);
             $logger->info('this is a test');
-
         } catch (Zend_Log_Exception $e) {
             $this->fail('Unable to load namespaced class');
         }
@@ -539,10 +545,10 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
     public function testZendLogCanBeExtendedWhenUsingFactory()
     {
         $writer = new Zend_Log_Writer_Null();
-        $log = ZLTest_My_Log::factory(
+        $log    = ZLTest_My_Log::factory(
             array(
                 'writerName' => $writer,
-                'className' => 'ZLTest_My_Log'
+                'className'  => 'ZLTest_My_Log'
             )
         );
         $this->assertTrue($log instanceof ZLTest_My_Log);
@@ -558,7 +564,7 @@ class Zend_Log_LogTest extends PHPUnit\Framework\TestCase
         ZLTest_My_Log::factory(
             array(
                 'writerName' => $writer,
-                'className' => 'ZLTest_My_LogNotExtending'
+                'className'  => 'ZLTest_My_LogNotExtending'
             )
         );
     }
@@ -595,5 +601,9 @@ class Custom_Formatter_Mock extends Zend_Log_Formatter_Abstract
  *
  * @group #85
  */
-class ZLTest_My_Log extends Zend_Log {}
-class ZLTest_My_LogNotExtending {}
+class ZLTest_My_Log extends Zend_Log
+{
+}
+class ZLTest_My_LogNotExtending
+{
+}

--- a/tests/Zend/Log/Writer/AbstractTest.php
+++ b/tests/Zend/Log/Writer/AbstractTest.php
@@ -81,7 +81,7 @@ class Zend_Log_Writer_AbstractTest_Concrete extends Zend_Log_Writer_Abstract
     {
     }
 
-    static public function factory($config)
+    public static function factory($config)
     {
     }
 }

--- a/tests/Zend/Log/Writer/MockTest.php
+++ b/tests/Zend/Log/Writer/MockTest.php
@@ -44,7 +44,7 @@ class Zend_Log_Writer_MockTest extends PHPUnit\Framework\TestCase
     public function testFactory()
     {
         $cfg = array('log' => array('memory' => array(
-            'writerName' => "Mock"
+            'writerName' => 'Mock'
         )));
 
         $logger = Zend_Log::factory($cfg['log']);

--- a/tests/Zend/Log/Writer/NullTest.php
+++ b/tests/Zend/Log/Writer/NullTest.php
@@ -43,7 +43,7 @@ class Zend_Log_Writer_NullTest extends PHPUnit\Framework\TestCase
     public function testFactory()
     {
         $cfg = array('log' => array('memory' => array(
-            'writerName' => "Null"
+            'writerName' => 'Null'
         )));
 
         $logger = Zend_Log::factory($cfg['log']);

--- a/tests/Zend/Log/Writer/StreamTest.php
+++ b/tests/Zend/Log/Writer/StreamTest.php
@@ -132,8 +132,8 @@ class Zend_Log_Writer_StreamTest extends PHPUnit\Framework\TestCase
 
     public function testSettingNewFormatter()
     {
-        $stream = fopen('php://memory', 'w+');
-        $writer = new Zend_Log_Writer_Stream($stream);
+        $stream   = fopen('php://memory', 'w+');
+        $writer   = new Zend_Log_Writer_Stream($stream);
         $expected = 'foo';
 
         $formatter = new Zend_Log_Formatter_Simple($expected);
@@ -150,7 +150,7 @@ class Zend_Log_Writer_StreamTest extends PHPUnit\Framework\TestCase
     public function testFactoryStream()
     {
         $cfg = array('log' => array('memory' => array(
-            'writerName'   => "Mock",
+            'writerName'   => 'Mock',
             'writerParams' => array(
                 'stream' => 'php://memory',
                 'mode'   => 'a'
@@ -164,7 +164,7 @@ class Zend_Log_Writer_StreamTest extends PHPUnit\Framework\TestCase
     public function testFactoryUrl()
     {
         $cfg = array('log' => array('memory' => array(
-            'writerName'   => "Mock",
+            'writerName'   => 'Mock',
             'writerParams' => array(
                 'url'  => 'http://localhost',
                 'mode' => 'a'

--- a/tests/Zend/Log/Writer/SyslogTest.php
+++ b/tests/Zend/Log/Writer/SyslogTest.php
@@ -111,11 +111,11 @@ class Zend_Log_Writer_SyslogTest extends PHPUnit\Framework\TestCase
     public function testWriteWithFormatter()
     {
         $event = array(
-        	'message' => 'tottakai',
+            'message'  => 'tottakai',
             'priority' => Zend_Log::ERR
         );
 
-        $writer = Zend_Log_Writer_Syslog::factory(array());
+        $writer    = Zend_Log_Writer_Syslog::factory(array());
         $formatter = new Zend_Log_Formatter_Simple('%message% (this is a test)');
         $writer->setFormatter($formatter);
 

--- a/tests/Zend/Log/_files/Zfns/Writer.php
+++ b/tests/Zend/Log/_files/Zfns/Writer.php
@@ -10,7 +10,7 @@ class Writer extends \Zend_Log_Writer_Abstract
      * @param  array|\Zend_Config $config
      * @return \Zend_Log_FactoryInterface
      */
-    static public function factory($config)
+    public static function factory($config)
     {
         return new self();
     }


### PR DESCRIPTION
Testing using php-cs-fixer and phpcs together to apply the (old) Zend standard.

phpcs still has the Zend standard, so using that mainly to check. The rules I’ve used for php-cs-fixer are close to what the Zend standard was but do a little bit more cleanup (that doesn’t violate the Zend standard, at least not in this component).