### PR TITLE
removing minimum stability from composer.json, cache fix for travis, making phpstan green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,17 @@ language: php
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
 env:
   global:
-    - COMPOSER_ARGS="" TMPDIR=/tmp USE_XDEBUG=false
+    - COMPOSER_ARGS=""
+    - TMPDIR=/tmp
+    - USE_XDEBUG=false
+    - COMPOSER_DISCARD_CHANGES=1
 
 branches:
   only:

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,6 @@
     ],
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "require": {
         "php": ">=7.0.0",
         "diablomedia/zendframework1-exception": "^1.0.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,7 +15,7 @@ parameters:
         # call_user_func does accept an array as the callable
         - '#Parameter \#1 \$function of function call_user_func expects callable\(\): mixed, array\(string, .factory.\) given\.#'
         -
-            message: '#Parameter \#2 \$priority of method Zend_Log::log\(\) expects int, int\|string\|false given\.#'
+            message: '#Parameter \#2 \$priority of method Zend_Log::log\(\) expects int, int\|string given\.#'
             path: %currentWorkingDirectory%/src/Zend/Log.php
         -
             message: '#Cannot assign offset int to array\|bool\.#'
@@ -26,3 +26,8 @@ parameters:
         -
             message: '#Parameter \#1 \$fp of function fwrite expects resource, resource\|null given\.#'
             path: %currentWorkingDirectory%/src/Zend/Log/Writer/Stream.php
+        # All of these are defensive coding in case an object isn't returned from _constructFromConfig (which is
+        # possible, since it's a call_user_func return)
+        -
+            message: '#Else branch is unreachable because ternary operator condition is always true.#'
+            path: %currentWorkingDirectory%/src/Zend/Log.php


### PR DESCRIPTION
Our cron build failed on this lib due to a different issue (phpstan not working due to bad dependency, which has since been fixed), which prompted me to remove the minimum-stability setting in composer.json since it really isn't needed in this lib and may prevent those errors from happening in the future.

PHPStan upgrade also made a few new errors, that are now ignored.